### PR TITLE
Added checks for Django project name & creation

### DIFF
--- a/setup_django_heroku.sh
+++ b/setup_django_heroku.sh
@@ -1,35 +1,50 @@
-# setup virtual environment and install dependencies
-virtualenv venv
-source venv/bin/activate
-pip install django dj-database-url gunicorn whitenoise
-pip freeze > requirements.txt
+function setup_django_heroku {
 
-# start Django project
-django-admin startproject "$1" .
-python manage.py makemigrations
-python manage.py migrate
+    # check that the arg for the Django project name was passed
+    if [ -z "$1" ]
+    then
+	echo "missing Django project name argument"
+	return 1
+    fi
 
-# add necessary Heroku files and settings
-python setup_django_heroku.py "$1"
-python manage.py collectstatic --noinput
+    # setup virtual environment and install dependencies
+    virtualenv venv && source venv/bin/activate
+    pip install django dj-database-url gunicorn whitenoise
+    pip freeze > requirements.txt
 
-# create Django admin
-printf "\n\n********************\nLet's create an admin user for you:\n\n"
-python manage.py createsuperuser
+    # create the Django project
+    django-admin startproject "$1" .
+    # check if there was an error starting the Django project
+    if [ $? != 0 ]
+    then
+	echo "error creating the Django project"
+	return 1
+    fi
 
-# create git repo, add first commit
-git init
-git add -A
-git commit -m "first commit"
+    # apply migrations
+    python manage.py makemigrations && python manage.py migrate
 
-# create Heroku app
-heroku create "$2"
+    # add necessary Heroku files and settings
+    python setup_django_heroku.py "$1"
+    python manage.py collectstatic --noinput
 
-# set Heroku config vars from the .env file
-while read line || [[ -n $line ]]; do heroku config:set $line; done < .env
+    # create Django admin
+    printf "\n\n********************\nLet's create an admin user for you:\n\n"
+    python manage.py createsuperuser
 
-# deploy!
-heroku git:remote -a "$2"
-git push heroku master
-heroku run python manage.py migrate
-heroku open
+    # create git repo, add first commit
+    git init
+    git add -A
+    git commit -m "first commit"
+
+    # set Heroku config vars from the .env file
+    while read line || [[ -n $line ]]; do heroku config:set $line; done < .env
+
+    # deploy!
+    heroku git:remote -a "$2"
+    git push heroku master
+    heroku run python manage.py migrate
+    heroku open
+
+    return 0
+}


### PR DESCRIPTION
I've moved the `sh`'s code into a Bash function, which checks that the user inputted a name for the Django project, and also if the project was successfully created. Although I've moved the code into a function, it can only be used within the same directory as the `.sh` file (because it looks for the `.py` file in the current folder). It shouldn't be hard to fix it but for now, this will suffice to check for the project name argument.